### PR TITLE
chore(ux): batch 5 checkbox wording clarity improvements

### DIFF
--- a/cn_indian_payroll/cn_indian_payroll/doctype/employee_bonus_accrual/employee_bonus_accrual.json
+++ b/cn_indian_payroll/cn_indian_payroll/doctype/employee_bonus_accrual/employee_bonus_accrual.json
@@ -118,7 +118,7 @@
    "default": "0",
    "fieldname": "is_paid",
    "fieldtype": "Check",
-   "label": "Is Paid"
+   "label": "Paid"
   },
   {
    "allow_on_submit": 1,

--- a/cn_indian_payroll/cn_indian_payroll/doctype/salary_component_library_item/salary_component_library_item.json
+++ b/cn_indian_payroll/cn_indian_payroll/doctype/salary_component_library_item/salary_component_library_item.json
@@ -109,7 +109,7 @@
    "depends_on": "eval:doc.type==\"Earning\"",
    "fieldname": "is_tax_applicable",
    "fieldtype": "Check",
-   "label": "Is Tax Applicable"
+   "label": "Tax Applicable"
   },
   {
    "default": "0",
@@ -121,7 +121,7 @@
    "default": "0",
    "fieldname": "is_income_tax_component",
    "fieldtype": "Check",
-   "label": "Is Income Tax Component"
+   "label": "Income Tax Component"
   },
   {
    "default": "0",
@@ -151,14 +151,14 @@
    "default": "0",
    "fieldname": "disabled",
    "fieldtype": "Check",
-   "label": "Disabled"
+   "label": "Inactive"
   },
   {
    "default": "0",
    "depends_on": "eval:doc.type==\"Earning\"",
    "fieldname": "is_part_of_ctc",
    "fieldtype": "Check",
-   "label": "Is Part of CTC"
+   "label": "Part of CTC"
   },
   {
    "default": "0",
@@ -209,7 +209,7 @@
    "default": "0",
    "fieldname": "is_flexible_benefit",
    "fieldtype": "Check",
-   "label": "Is Flexible Benefit"
+   "label": "Flexible Benefit"
   },
   {
    "fieldname": "max_benefit_amount_yearly",


### PR DESCRIPTION
## Summary
Implements a small, low-risk UX wording cleanup for checkbox labels to reduce cognitive load in payroll forms.

## Changes
Updated labels in:
- `salary_component_library_item`
  - `Is Tax Applicable` -> `Tax Applicable`
  - `Is Income Tax Component` -> `Income Tax Component`
  - `Disabled` -> `Inactive`
  - `Is Part of CTC` -> `Part of CTC`
  - `Is Flexible Benefit` -> `Flexible Benefit`
- `employee_bonus_accrual`
  - `Is Paid` -> `Paid`

## Why
These are user-facing text simplifications only; no functional changes.

## Validation
- JSON metadata valid.
- No schema changes.

Closes #117
