### PR TITLE
fix(stability): remove unsafe manual commits from override workflows

### DIFF
--- a/cn_indian_payroll/cn_indian_payroll/overrides/loan_application.py
+++ b/cn_indian_payroll/cn_indian_payroll/overrides/loan_application.py
@@ -37,7 +37,6 @@ def hold_installments(employee, payment_date, company, type, number_of_months, d
                 repayment.db_update()
 
         repayment_doc.save(ignore_permissions=True)
-        frappe.db.commit()
 
         return "success"
 
@@ -84,7 +83,6 @@ def hold_installments(employee, payment_date, company, type, number_of_months, d
             repayment_doc.remove(r)
 
         repayment_doc.save(ignore_permissions=True)
-        frappe.db.commit()
 
         return "success"
 
@@ -140,7 +138,6 @@ def hold_installments(employee, payment_date, company, type, number_of_months, d
             prev_balance = repayment.balance_loan_amount
 
         repayment_doc.save(ignore_permissions=True)
-        frappe.db.commit()
         return "success"
 
 

--- a/cn_indian_payroll/cn_indian_payroll/overrides/payroll_entry.py
+++ b/cn_indian_payroll/cn_indian_payroll/overrides/payroll_entry.py
@@ -23,7 +23,6 @@ class PayrollEntryOverride(PayrollEntry):
             for doc in joinee_arrear:
                 doc = frappe.get_doc("New Joining Arrear", doc)
                 doc.cancel()
-                frappe.db.commit()
 
     def submit_new_joinee_arrear(self):
         joinee_arrear = frappe.get_all(
@@ -33,7 +32,6 @@ class PayrollEntryOverride(PayrollEntry):
             for doc in joinee_arrear:
                 doc = frappe.get_doc("New Joining Arrear", doc)
                 doc.submit()
-                frappe.db.commit()
 
     def make_filters(self):
         filters = frappe._dict(
@@ -165,7 +163,6 @@ class PayrollEntryOverride(PayrollEntry):
                                     }
                                 )
                                 arrear_doc.insert(ignore_permissions=True)
-                                frappe.db.commit()
 
                     elif payroll_setting.payroll_based_on == "Leave":
                         existing_doc = frappe.db.exists(
@@ -185,7 +182,6 @@ class PayrollEntryOverride(PayrollEntry):
                                 }
                             )
                             arrear_doc.insert(ignore_permissions=True)
-                            frappe.db.commit()
 
                     continue
 

--- a/cn_indian_payroll/cn_indian_payroll/overrides/salary_structure_assignment.py
+++ b/cn_indian_payroll/cn_indian_payroll/overrides/salary_structure_assignment.py
@@ -256,7 +256,6 @@ class CustomSalaryStructureAssignment(SalaryStructureAssignment):
             declaration.insert()
             declaration.submit()
 
-        frappe.db.commit()
 
 
 @frappe.whitelist()

--- a/cn_indian_payroll/cn_indian_payroll/overrides/tax_declaration.py
+++ b/cn_indian_payroll/cn_indian_payroll/overrides/tax_declaration.py
@@ -249,7 +249,6 @@ class CustomEmployeeTaxExemptionDeclaration(EmployeeTaxExemptionDeclaration):
                     )
 
                 each_doc.save()
-                frappe.db.commit()
 
     def update_tax_declaration(self):
         if len(self.declarations) > 0:
@@ -328,7 +327,6 @@ class CustomEmployeeTaxExemptionDeclaration(EmployeeTaxExemptionDeclaration):
                     )
 
                 each_doc.save()
-                frappe.db.commit()
 
             else:
                 insert_history = frappe.get_doc(
@@ -372,7 +370,6 @@ class CustomEmployeeTaxExemptionDeclaration(EmployeeTaxExemptionDeclaration):
                 )
 
                 insert_history.insert()
-                frappe.db.commit()
 
     def insert_declaration_history(self):
         if self.employee:


### PR DESCRIPTION
## Summary
Removes unsafe manual `frappe.db.commit()` calls from override flows so transaction handling remains framework-managed.

## Files changed
- `cn_indian_payroll/cn_indian_payroll/overrides/payroll_entry.py`
- `cn_indian_payroll/cn_indian_payroll/overrides/loan_application.py`
- `cn_indian_payroll/cn_indian_payroll/overrides/tax_declaration.py`
- `cn_indian_payroll/cn_indian_payroll/overrides/salary_structure_assignment.py`

## Why
Manual commits inside request/workflow code can persist partial writes if downstream logic fails. This patch removes those commits to preserve transaction consistency.

## Validation
- Python compile check passed for all modified files.
- No business logic changes besides transaction boundary handling.

Closes #106
